### PR TITLE
Fix a bug in gbAlert

### DIFF
--- a/GBJSTK.js
+++ b/GBJSTK.js
@@ -463,7 +463,7 @@ function gbAlert( title, message )
 	}
 	else 
 	{
-		alert.log(title + '\n' + message);
+		alert(title + '\n' + message);
 	}
 }
 


### PR DESCRIPTION
This fixes a bug in the Good Barber Javascript Toolkit for Plugins, where displaying an alert was previously not working.